### PR TITLE
State lifetimes and delegate optimization

### DIFF
--- a/src/reactive-bs-sdk/Reactive.BeatSaber/Components/Image/WebImage.cs
+++ b/src/reactive-bs-sdk/Reactive.BeatSaber/Components/Image/WebImage.cs
@@ -78,7 +78,7 @@ public class WebImage : Image {
             }
             .WithNativeComponent(out CanvasGroup group)
             .AsBackground()
-            .On(_backgroundAlpha, (x, y) => x.Color = Color.black.ColorWithAlpha(y), applyImmediately: true)
+            .On(_backgroundAlpha, (x, y) => x.Color = Color.black.ColorWithAlpha(y))
             .On(_spinnerAlpha, (_, y) => group.alpha = y)
             .AsFlexGroup(justifyContent: Justify.Center, alignItems: Align.Center)
             .WithRectExpand()

--- a/src/reactive-bs-sdk/Reactive.BeatSaber/Components/InputField/InputField.cs
+++ b/src/reactive-bs-sdk/Reactive.BeatSaber/Components/InputField/InputField.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Reactive.Compiler;
 using Reactive.Components;
@@ -15,16 +14,13 @@ public partial class InputField : ReactiveComponent, IGraphic {
     #region Public API
 
     [RawState, Required]
-    [field: AllowNull]
     public InputFieldContext Context {
         get;
         set {
-            if (field != null) {
-                field.ValueChangedEvent -= HandleContextUpdated;
-            }
+            _contextSubscription?.RemoveCallback();
 
             field = value;
-            field.ValueChangedEvent += HandleContextUpdated;
+            _contextSubscription = field.AddCallback(HandleContextUpdated);
             
             HandleContextUpdated(field);
         }
@@ -34,6 +30,8 @@ public partial class InputField : ReactiveComponent, IGraphic {
         get => _placeholder.Value;
         set => _placeholder.Value = value;
     }
+
+    private StateSubscription? _contextSubscription;
 
     private void HandleContextUpdated(InputFieldContext context) {
         _focused.Value = context.Focused;

--- a/src/reactive-bs-sdk/Reactive.BeatSaber/Components/InputField/InputFieldContext.cs
+++ b/src/reactive-bs-sdk/Reactive.BeatSaber/Components/InputField/InputFieldContext.cs
@@ -1,15 +1,14 @@
-using System;
 using JetBrains.Annotations;
 
 namespace Reactive.BeatSaber.Components;
 
 [PublicAPI]
-public class InputFieldContext : IState<InputFieldContext> {
+public class InputFieldContext : StateBase<InputFieldContext>, IState<InputFieldContext> {
     public string? Text {
         get;
         set {
             field = value;
-            NotifyValueChanged();
+            NotifyValueChanged(this);
         }
     }
 
@@ -17,21 +16,9 @@ public class InputFieldContext : IState<InputFieldContext> {
         get;
         set {
             field = value;
-            NotifyValueChanged();
+            NotifyValueChanged(this);
         }
     }
 
-    #region State Impl
-
     InputFieldContext IState<InputFieldContext>.Value => this;
-    
-    public event Action<InputFieldContext>? ValueChangedEvent;
-    public event Action? StateUpdatedEvent;
-
-    private void NotifyValueChanged() {
-        ValueChangedEvent?.Invoke(this);
-        StateUpdatedEvent?.Invoke();
-    }
-
-    #endregion
 }

--- a/src/reactive-bs-sdk/Reactive.BeatSaber/Components/Table/Scrollbar.cs
+++ b/src/reactive-bs-sdk/Reactive.BeatSaber/Components/Table/Scrollbar.cs
@@ -24,12 +24,10 @@ namespace Reactive.BeatSaber.Components {
         public ScrollContext ScrollContext {
             get => _scrollContext!;
             set {
-                if (_scrollContext != null) {
-                    _scrollContext.ValueChangedEvent -= HandleContextUpdated;
-                }
+                _scrollContextSubscription?.RemoveCallback();
 
                 _scrollContext = value;
-                _scrollContext.ValueChangedEvent += HandleContextUpdated;
+                _scrollContextSubscription = _scrollContext.AddCallback(HandleContextUpdated);
 
                 HandleContextUpdated(value);
             }
@@ -60,6 +58,7 @@ namespace Reactive.BeatSaber.Components {
         private IMutableState<ScrollContext?> _scrollContextState = null!;
         private IMutableState<bool> _hideIfNothingToScroll;
         private ScrollContext? _scrollContext;
+        private StateSubscription? _scrollContextSubscription;
 
         #endregion
 

--- a/src/reactive-sdk/Reactive.Components/Components/ListView/Repeater.cs
+++ b/src/reactive-sdk/Reactive.Components/Components/ListView/Repeater.cs
@@ -194,7 +194,7 @@ namespace Reactive.Components {
 
                 if (i >= _cells.Count) {
                     context = new CellContext<TItem>();
-                    context.ValueChangedEvent += HandleCellContextUpdated;
+                    context.AddCallback(HandleCellContextUpdated);
 
                     context.Init(item, i, Items.Count);
 

--- a/src/reactive-sdk/Reactive.Components/Components/ScrollArea/ScrollArea.cs
+++ b/src/reactive-sdk/Reactive.Components/Components/ScrollArea/ScrollArea.cs
@@ -19,7 +19,7 @@ namespace Reactive.Components.Basic {
         public ScrollContext ScrollContext {
             get => _scrollContext!;
             set {
-                _scrollContext?.ValueChangedEvent -= HandleContextUpdated;
+                _scrollContextSubscription?.RemoveCallback();
                 _scrollContext = value;
 
                 var didInitialUpdate = DoInitialUpdate();
@@ -27,7 +27,7 @@ namespace Reactive.Components.Basic {
                     RefreshMeasurements();
                 }
 
-                _scrollContext.ValueChangedEvent += HandleContextUpdated;
+                _scrollContextSubscription = _scrollContext.AddCallback(HandleContextUpdated);
                 HandleContextUpdated(_scrollContext);
             }
         }
@@ -60,6 +60,7 @@ namespace Reactive.Components.Basic {
         private IReactiveComponent? _scrollContent;
         private RectTransform? _contentTransform;
         private ScrollContext? _scrollContext;
+        private StateSubscription? _scrollContextSubscription;
         private bool _needsInitialUpdate = true;
 
         private bool DoInitialUpdate() {

--- a/src/reactive-sdk/Reactive.Components/Components/ScrollArea/ScrollContext.cs
+++ b/src/reactive-sdk/Reactive.Components/Components/ScrollArea/ScrollContext.cs
@@ -19,7 +19,7 @@ public enum ScrollUpdateType {
 }
 
 [PublicAPI]
-public class ScrollContext : IState<ScrollContext> {
+public class ScrollContext : StateBase<ScrollContext>, IState<ScrollContext> {
     /// <summary>
     /// Determines the current scroll pos. Set by the user.
     /// </summary>
@@ -164,14 +164,10 @@ public class ScrollContext : IState<ScrollContext> {
 
     ScrollContext IState<ScrollContext>.Value => this;
 
-    public event Action<ScrollContext>? ValueChangedEvent;
-    public event Action? StateUpdatedEvent;
-
     private void NotifyValueChanged(ScrollUpdateType type) {
         UpdateType = type;
 
-        ValueChangedEvent?.Invoke(this);
-        StateUpdatedEvent?.Invoke();
+        NotifyValueChanged(this);
 
         UpdateType = ScrollUpdateType.None;
     }

--- a/src/reactive-sdk/Reactive.Components/Components/Table/CellContext.cs
+++ b/src/reactive-sdk/Reactive.Components/Components/Table/CellContext.cs
@@ -9,7 +9,7 @@ public enum CellUpdateType {
     Selection
 }
 
-public class CellContext<T> : IState<CellContext<T>> {
+public class CellContext<T> : StateBase<CellContext<T>>, IState<CellContext<T>> {
     public T Item => _item ?? throw new();
 
     public int Index { get; private set; }
@@ -59,15 +59,11 @@ public class CellContext<T> : IState<CellContext<T>> {
     #region State
 
     public CellContext<T> Value => this;
-
-    public event Action<CellContext<T>>? ValueChangedEvent;
-    public event Action? StateUpdatedEvent;
-
+    
     private void NotifyValueChanged(CellUpdateType type) {
         UpdateType = type;
 
-        ValueChangedEvent?.Invoke(this);
-        StateUpdatedEvent?.Invoke();
+        NotifyValueChanged(this);
 
         UpdateType = CellUpdateType.None;
     }

--- a/src/reactive-sdk/Reactive.Components/Components/Table/Table.cs
+++ b/src/reactive-sdk/Reactive.Components/Components/Table/Table.cs
@@ -20,13 +20,11 @@ namespace Reactive.Components.Basic {
         public ScrollContext ScrollContext {
             get => _scrollContext!;
             set {
-                if (_scrollContext != null) {
-                    _scrollContext.ValueChangedEvent -= HandleScrollContextUpdated;
-                }
+                _scrollContextSubscription?.RemoveCallback();
 
                 _scrollArea.ScrollContext = value;
                 _scrollContext = value;
-                _scrollContext.ValueChangedEvent += HandleScrollContextUpdated;
+                _scrollContextSubscription = _scrollContext.AddCallback(HandleScrollContextUpdated);
 
                 DoInitialUpdate();
             }
@@ -122,6 +120,7 @@ namespace Reactive.Components.Basic {
         private Func<CellContext<TItem>, TCell>? _constructCell;
         private IReadOnlyList<TItem>? _items;
         private ScrollContext? _scrollContext;
+        private StateSubscription? _scrollContextSubscription;
         private bool _needsInitialUpdate = true;
 
         private void DoInitialUpdate() {

--- a/src/reactive/Reactive.Compiler.Sample/Sample.cs
+++ b/src/reactive/Reactive.Compiler.Sample/Sample.cs
@@ -8,6 +8,9 @@ public class Sample : ReactiveComponent {
         var text = Remember("");
         var color = RememberAnimated(Color.blue, 200.ms);
 
+        text.AddCallback(Debug.Log);
+        color.AddCallback(static x => Debug.Log(x));
+
         return new Layout {
             FlexController = {
                 FlexDirection = FlexDirection.Column,
@@ -20,10 +23,6 @@ public class Sample : ReactiveComponent {
 
             Children = {
                 new Label {
-                    Do = x => x
-                        .On(text, Debug.Log)
-                        .On(color, x => Debug.Log(x)),
-
                     DoAll = [
                         x => Debug.Log(x),
                         x => Debug.Log(x),

--- a/src/reactive/Reactive.Compiler/Features/StateBinder/StateGenerator.cs
+++ b/src/reactive/Reactive.Compiler/Features/StateBinder/StateGenerator.cs
@@ -68,7 +68,7 @@ internal class StateGenerator : IIncrementalGenerator {
         if (GetPatterns(assignment, semanticModel) is not { } patterns) {
             return null;
         }
-        
+
         // Ignoring state type here as we simply need to ensure that the resulting 
         // object is IState, the target type is taken from the target property
         if (!assignment.Right.IsStateExpression(semanticModel)) {
@@ -138,8 +138,8 @@ internal class StateGenerator : IIncrementalGenerator {
                 // Raw states are excluded from the generation process
                 if (symbol.GetDerivedAttribute<RawStateAttribute>(semanticModel) != null) {
                     continue;
-                } 
-                
+                }
+
                 return (prop.OriginalDefinition, statePropName);
             }
         }
@@ -150,47 +150,30 @@ internal class StateGenerator : IIncrementalGenerator {
     private static string GenerateTypeExtension(INamedTypeSymbol type, IEnumerable<IGrouping<ISymbol?, string>> propGroups) {
         var inner = new StringBuilder();
 
+        var binder = StateGeneratorUtils.IsUnityObject(type) ? "AddCallbackUnity" : "AddCallback";
+
         foreach (var nameGroup in propGroups) {
             var prop = nameGroup.Key!;
-            var propType = SemanticExtensions.GetReturnType(prop);
-            var propName = prop.Name;
+            var propType = SemanticExtensions.GetReturnType(prop)!;
+            var sourcePropName = prop.Name;
 
-            foreach (var name in nameGroup) {
-                var definition = """
-                                 [Reactive.Compiler.SetsRequiredAttribute(Names = ["{4}"])]
-                                 public {0}<{2}, {1}<{2}>> {3} {{
-                                     set {{
-                                         value.Attach(x => obj.{4} = x);
-                                     }}
-                                 }}
+            foreach (var propName in nameGroup) {
+                var propExtension = GenerateProp(propType, propName, sourcePropName, binder);
 
-                                 """;
-
-                // Replace placeholders
-                definition = string.Format(
-                    definition,
-                    StateGeneratorUtils.StateBinderPath, // StateBinder<>
-                    StateGeneratorUtils.StatePath, // IState<>
-                    propType,                      // State target type (State<T>)
-                    name,                          // Prop name
-                    propName                       // Target prop name
-                );
-
-                // Prettify
-                definition = definition.Insert(0, "\t\t").Replace("\n", "\n\t\t");
-
-                inner.AppendLine(definition);
+                inner.AppendLine(propExtension);
             }
         }
 
-        var outer = """
-                    [System.CodeDom.Compiler.GeneratedCode("Reactive_StateGenerator", "1.0")]
-                    internal static class Reactive_{0}_StateGenExt {{
-                        extension{3}({1} obj) {4} {{
-                    {2}
-                        }}
-                    }}
-                    """;
+        var outer =
+            """
+            [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+            [System.CodeDom.Compiler.GeneratedCode("Reactive_StateGenerator", "1.0")]
+            internal static class Reactive_{0}_StateGenExt {{
+                extension{3}({1} obj) {4} {{
+            {2}
+                }}
+            }}
+            """;
 
         var typeIdentifier = type.GetTypeIdentifier();
 
@@ -206,6 +189,31 @@ internal class StateGenerator : IIncrementalGenerator {
             genericConstrainments
         );
 
-        return outer;
+        return outer.Insert(0, "\t\t").Replace("\n", "\n\t\t");
+    }
+
+    private static string GenerateProp(ITypeSymbol stateType, string propName, string sourcePropName, string binderMethodName) {
+        var definition =
+            """
+            [Reactive.Compiler.SetsRequiredAttribute(Names = ["{4}"])]
+            public {0}<{2}, {1}<{2}>> {3} {{
+                set {{
+                    value.{5}(obj, static (x, y) => x.{4} = y);
+                }}
+            }}
+
+            """;
+
+        definition = string.Format(
+            definition,
+            StateGeneratorUtils.StateBinderPath, // StateBinder<>
+            StateGeneratorUtils.StatePath,       // IState<>
+            stateType,                           // State target type (State<T>)
+            propName,                            // Prop name
+            sourcePropName,                      // Target prop name
+            binderMethodName                     // Binder name (e.g. AddCallback)
+        );
+
+        return definition;
     }
 }

--- a/src/reactive/Reactive.Compiler/Features/StateBinder/StateGeneratorUtils.cs
+++ b/src/reactive/Reactive.Compiler/Features/StateBinder/StateGeneratorUtils.cs
@@ -31,6 +31,20 @@ internal static class StateGeneratorUtils {
             .Any(x => x.IsStateType());
     }
 
+    public static bool IsUnityObject(ITypeSymbol symbol) {
+        var current = symbol;
+        
+        while (current != null) {
+            if (current.ToDisplayString() == "UnityEngine.Object") {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
     public static bool IsStateType(this ISymbol? symbol) {
         return symbol is ITypeSymbol type && (IsStateTypeSelf(type) || type.AllInterfaces.Any(IsStateTypeSelf));
     }

--- a/src/reactive/Reactive/Animations/AnimatedState.cs
+++ b/src/reactive/Reactive/Animations/AnimatedState.cs
@@ -8,7 +8,7 @@ namespace Reactive {
     /// </summary>
     /// <typeparam name="T">A type of the state.</typeparam>
     [PublicAPI]
-    public class AnimatedState<T> : IState<T>, IReactiveModule {
+    public class AnimatedState<T> : StateBase<T>, IState<T>, IReactiveModule {
         public AnimatedState(T initialValue, IValueInterpolator<T> valueInterpolator) {
             _startValue = initialValue;
             _targetValue = initialValue;
@@ -16,6 +16,7 @@ namespace Reactive {
             _set = true;
             _progress = 1f;
             _elapsedTime = 0f;
+            Value = _valueInterpolator.Lerp(_startValue, _targetValue, _progress);
         }
 
         public T TargetValue {
@@ -44,12 +45,13 @@ namespace Reactive {
             get => _progress;
             private set {
                 _progress = value;
-                ValueChangedEvent?.Invoke(Value);
-                StateUpdatedEvent?.Invoke();
+                Value = _valueInterpolator.Lerp(_startValue, _targetValue, _progress);
+                NotifyValueChanged(Value);
             }
         }
-        
-        public T Value => _valueInterpolator.Lerp(_startValue, _targetValue, _progress);
+
+        public T Value { get; private set; }
+
         public bool IsFinished => _set;
 
         public AnimationDuration Duration { get; set; }
@@ -57,9 +59,6 @@ namespace Reactive {
 
         public Action<T>? OnFinish { get; set; }
         public Action<T>? OnStart { get; set; }
-
-        public event Action<T>? ValueChangedEvent;
-        public event Action? StateUpdatedEvent;
 
         private readonly IValueInterpolator<T> _valueInterpolator;
         private T _targetValue;

--- a/src/reactive/Reactive/Compiler/StateBinder.cs
+++ b/src/reactive/Reactive/Compiler/StateBinder.cs
@@ -19,7 +19,7 @@ public readonly ref struct StateBinder<T, TState> where TState : IState<T> {
             throw new InvalidOperationException("StateBinder wasn't initialized");
         }
 
-        _state.ValueChangedEvent += callback;
+        _state.AddCallback(callback);
 
         if (!_lazy) {
             callback(_state.Value);

--- a/src/reactive/Reactive/Compiler/StateBinder.cs
+++ b/src/reactive/Reactive/Compiler/StateBinder.cs
@@ -13,16 +13,22 @@ public readonly ref struct StateBinder<T, TState> where TState : IState<T> {
         _state = state;
         _lazy = lazy;
     }
-    
-    public void Attach(Action<T> callback) {
+
+    public void AddCallback<TComp>(TComp comp, Action<TComp, T> callback) where TComp : ILifetimeProvider {
+        EnsureInitialized();
+        
+        _state!.AddCallback(comp, callback, _lazy);
+    }
+
+    public void AddCallbackUnity<TComp>(TComp comp, Action<TComp, T> callback) where TComp : UnityEngine.Object {
+        EnsureInitialized();
+        
+        _state!.AddCallbackUnity(comp, callback, _lazy);
+    }
+
+    private void EnsureInitialized() {
         if (_state == null) {
             throw new InvalidOperationException("StateBinder wasn't initialized");
-        }
-
-        _state.AddCallback(callback);
-
-        if (!_lazy) {
-            callback(_state.Value);
         }
     }
 
@@ -37,7 +43,7 @@ public static class StateBinderExtensions {
         public StateBinder<T, IState<T>> In() {
             return new(binder, false);
         }
-        
+
         public StateBinder<T, IState<T>> InLazy() {
             return new(binder, true);
         }

--- a/src/reactive/Reactive/IReactiveComponent.cs
+++ b/src/reactive/Reactive/IReactiveComponent.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace Reactive {
     [PublicAPI]
-    public interface IReactiveComponent : ILayoutItem, IReactiveModuleBinder {
+    public interface IReactiveComponent : ILayoutItem, IReactiveModuleBinder, ILifetimeProvider {
         GameObject Content { get; }
         RectTransform ContentTransform { get; }
 

--- a/src/reactive/Reactive/ReactiveComponent.cs
+++ b/src/reactive/Reactive/ReactiveComponent.cs
@@ -221,6 +221,7 @@ namespace Reactive {
 
         public bool IsInitialized { get; private set; }
         public bool IsDestroyed { get; private set; }
+        bool ILifetimeProvider.IsAlive => !IsDestroyed;
 
         protected Canvas? Canvas {
             get {

--- a/src/reactive/Reactive/States/BranchedState.cs
+++ b/src/reactive/Reactive/States/BranchedState.cs
@@ -8,7 +8,7 @@ namespace Reactive;
 /// an ability to set a condition over state updates.
 /// </summary>
 [PublicAPI]
-public class BranchedState<T> : IState<T>, IDisposable {
+public class BranchedState<T> : StateBase<T>, IState<T>, IDisposable {
     /// <summary>
     /// Represents a state value. Keep in mind that it returns the last value
     /// that met branching conditions, so it's not guaranteed that the value is equal to the original one.
@@ -17,28 +17,28 @@ public class BranchedState<T> : IState<T>, IDisposable {
     /// </summary>
     public T Value { get; private set; }
 
-    public event Action<T>? ValueChangedEvent;
-    public event Action? StateUpdatedEvent;
-
     private readonly IState<T> _state;
     private readonly Func<T, bool> _predicate;
+    private readonly StateSubscription _subscription;
 
     public BranchedState(IState<T> state, Func<T, bool> predicate) {
         _state = state;
         _predicate = predicate;
-        
+
         Value = state.Value;
-        state.ValueChangedEvent += HandleValueChanged;
+        _subscription = state.AddCallback(HandleValueChanged, this, null!);
     }
 
-    private void HandleValueChanged(T value) {
-        if (_predicate(value)) {
-            Value = value;
-            ValueChangedEvent?.Invoke(value);
+    private static void HandleValueChanged(ref RefStateSubscription sub, T value, object arg1, object arg2) {
+        var self = (BranchedState<T>)arg1;
+
+        if (self._predicate(value)) {
+            self.Value = value;
+            self.NotifyValueChanged(value);
         }
     }
 
     public void Dispose() {
-        _state.ValueChangedEvent -= HandleValueChanged;
+        _state.RemoveCallback(_subscription);
     }
 }

--- a/src/reactive/Reactive/States/DerivedState.cs
+++ b/src/reactive/Reactive/States/DerivedState.cs
@@ -9,43 +9,53 @@ namespace Reactive;
 /// A wrapper class over <see cref="IState"/> that updates when one of the dependencies does.
 /// </summary>
 [PublicAPI]
-public class DerivedState<T, TDeps> : IState<T>, IDisposable where TDeps : ITuple {
-    public T Value => _predicate(_dependencies);
-
-    public event Action<T>? ValueChangedEvent;
-    public event Action? StateUpdatedEvent;
+public class DerivedState<T, TDeps> : StateBase<T>, IState<T>, IDisposable where TDeps : ITuple {
+    public T Value {
+        get {
+            _value ??= _predicate(_dependencies);
+            return _value;
+        }
+    }
 
     private readonly TDeps _dependencies;
     private readonly Func<TDeps, T> _predicate;
+    private readonly StateSubscription[] _subscriptions;
+    private readonly int _occupiedSubsLen;
+    private T? _value;
 
     public DerivedState(Func<TDeps, T> predicate, TDeps dependencies) {
         _dependencies = dependencies;
         _predicate = predicate;
+        _subscriptions = new StateSubscription[dependencies.Length];
 
         // C# does not support variadic generics (or templates) as C++ does,
         // hence to avoid writing custom generators or lots of boilerplate,
         // we use this workaround as a "temporary" solution
-        
+
         for (var i = 0; i < dependencies.Length; i++) {
             // Non-state objects are simply ignored
             if (dependencies[i] is IState state) {
-                state.StateUpdatedEvent += HandleStateUpdated;
+                _subscriptions[_occupiedSubsLen] = state.AddCallback(HandleStateUpdated, this, null!);
+                _occupiedSubsLen++;
             } else {
                 Debug.LogWarning("You've passed a dependency which is not a state, consider removing it and passing directly");
             }
         }
     }
 
-    private void HandleStateUpdated() {
-        ValueChangedEvent?.Invoke(_predicate(_dependencies));
-        StateUpdatedEvent?.Invoke();
+    private static void HandleStateUpdated(ref RefStateSubscription sub, object arg1, object arg2) {
+        var self = (DerivedState<T, TDeps>)arg1;
+
+        self._value = default;
+
+        if (self.HasCallbacks) {
+            self.NotifyValueChanged(self.Value);
+        }
     }
 
     public void Dispose() {
-        for (var i = 0; i < _dependencies.Length; i++) {
-            if (_dependencies[i] is IState state) {
-                state.StateUpdatedEvent -= HandleStateUpdated;
-            }
+        for (var i = 0; i < _occupiedSubsLen; i++) {
+            _subscriptions[i].RemoveCallback();
         }
     }
 }

--- a/src/reactive/Reactive/States/DerivedState.cs
+++ b/src/reactive/Reactive/States/DerivedState.cs
@@ -12,8 +12,11 @@ namespace Reactive;
 public class DerivedState<T, TDeps> : StateBase<T>, IState<T>, IDisposable where TDeps : ITuple {
     public T Value {
         get {
-            _value ??= _predicate(_dependencies);
-            return _value;
+            if (!_hasValue) {
+                field = _predicate(_dependencies);
+            }
+            
+            return field;
         }
     }
 
@@ -21,7 +24,7 @@ public class DerivedState<T, TDeps> : StateBase<T>, IState<T>, IDisposable where
     private readonly Func<TDeps, T> _predicate;
     private readonly StateSubscription[] _subscriptions;
     private readonly int _occupiedSubsLen;
-    private T? _value;
+    private bool _hasValue;
 
     public DerivedState(Func<TDeps, T> predicate, TDeps dependencies) {
         _dependencies = dependencies;
@@ -46,7 +49,7 @@ public class DerivedState<T, TDeps> : StateBase<T>, IState<T>, IDisposable where
     private static void HandleStateUpdated(ref RefStateSubscription sub, object arg1, object arg2) {
         var self = (DerivedState<T, TDeps>)arg1;
 
-        self._value = default;
+        self._hasValue = false;
 
         if (self.HasCallbacks) {
             self.NotifyValueChanged(self.Value);

--- a/src/reactive/Reactive/States/ILifetimeProvider.cs
+++ b/src/reactive/Reactive/States/ILifetimeProvider.cs
@@ -1,0 +1,22 @@
+using JetBrains.Annotations;
+
+namespace Reactive;
+
+/// <summary>
+/// Represents an object that has a lifetime. Used by the compiler to determine
+/// whether a state binding remains valid. By default, you can use state generator on
+/// unity objects and classes that implement IReactiveComponent. To use it on your own
+/// classes you must implement this interface.
+/// </summary>
+[PublicAPI]
+public interface ILifetimeProvider {
+    bool IsAlive { get; }
+}
+
+[PublicAPI]
+public static class LifetimeExtensions {
+    extension(UnityEngine.Object obj) {
+        // Allows the compiler to blindly do IsAlive calls
+        public bool IsAlive => obj != null;
+    }
+}

--- a/src/reactive/Reactive/States/IState.cs
+++ b/src/reactive/Reactive/States/IState.cs
@@ -1,29 +1,26 @@
-﻿using System;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 
-namespace Reactive {
-    /// <summary>
-    /// Represents a reactive state.
-    /// </summary>
-    /// <typeparam name="T">A type of the state.</typeparam>
-    [PublicAPI]
-    public interface IState<out T> : IState {
-        T Value { get; }
+namespace Reactive;
 
-        /// <summary>
-        /// Fired whenever the state is updated.
-        /// </summary>
-        event Action<T>? ValueChangedEvent;
-    }
-    
-    /// <summary>
-    /// Represents a non-generic state.
-    /// </summary>
-    [PublicAPI]
-    public interface IState {
-        /// <summary>
-        /// Fired whenever the state is updated.
-        /// </summary>
-        event Action? StateUpdatedEvent;
-    }
+public delegate void StateCallback(ref RefStateSubscription sub, object arg1, object arg2);
+public delegate void StateCallback<in T>(ref RefStateSubscription sub, T value, object arg1, object arg2);
+
+/// <summary>
+/// Represents a reactive state.
+/// </summary>
+/// <typeparam name="T">A type of the state.</typeparam>
+[PublicAPI]
+public interface IState<out T> : IState {
+    T Value { get; }
+
+    StateSubscription AddCallback(StateCallback<T> callback, object arg1, object arg2);
+}
+
+/// <summary>
+/// Represents a non-generic reactive state.
+/// </summary>
+[PublicAPI]
+public interface IState {
+    StateSubscription AddCallback(StateCallback callback, object arg1, object arg2);
+    bool RemoveCallback(in StateSubscription sub);
 }

--- a/src/reactive/Reactive/States/MappedState.cs
+++ b/src/reactive/Reactive/States/MappedState.cs
@@ -8,30 +8,39 @@ namespace Reactive;
 /// an ability to map a state value.
 /// </summary>
 [PublicAPI]
-public class MappedState<T, TNew> : IState<TNew>, IDisposable {
+public class MappedState<T, TNew> : StateBase<TNew>, IState<TNew>, IDisposable {
     /// <summary>
     /// Represents a state value. Evaluated on each call.
     /// </summary>
-    public TNew Value => _predicate(_state.Value);
-    
-    public event Action<TNew>? ValueChangedEvent;
-    public event Action? StateUpdatedEvent;
+    public TNew Value {
+        get {
+            _value ??= _predicate(_state.Value);
+            return _value;
+        }
+    }
 
     private readonly IState<T> _state;
     private readonly Func<T, TNew> _predicate;
+    private StateSubscription _subscription;
+    private TNew? _value;
 
     public MappedState(IState<T> state, Func<T, TNew> predicate) {
         _state = state;
         _predicate = predicate;
-        state.ValueChangedEvent += HandleValueChanged;
+        _subscription = state.AddCallback(HandleValueChanged, this, null!);
     }
 
-    private void HandleValueChanged(T value) {
-        ValueChangedEvent?.Invoke(_predicate(value));
-        StateUpdatedEvent?.Invoke();
+    private static void HandleValueChanged(ref RefStateSubscription _, T value, object arg1, object arg2) {
+        var self = (MappedState<T, TNew>)arg1;
+        
+        self._value = default;
+
+        if (self.HasCallbacks) {
+            self.NotifyValueChanged(self.Value);
+        }
     }
 
     public void Dispose() {
-        _state.ValueChangedEvent -= HandleValueChanged;
+        _state.RemoveCallback(_subscription);
     }
 }

--- a/src/reactive/Reactive/States/MappedState.cs
+++ b/src/reactive/Reactive/States/MappedState.cs
@@ -14,15 +14,18 @@ public class MappedState<T, TNew> : StateBase<TNew>, IState<TNew>, IDisposable {
     /// </summary>
     public TNew Value {
         get {
-            _value ??= _predicate(_state.Value);
-            return _value;
+            if (!_hasValue) {
+                field = _predicate(_state.Value);
+            }
+
+            return field;
         }
     }
 
     private readonly IState<T> _state;
     private readonly Func<T, TNew> _predicate;
     private StateSubscription _subscription;
-    private TNew? _value;
+    private bool _hasValue;
 
     public MappedState(IState<T> state, Func<T, TNew> predicate) {
         _state = state;
@@ -32,8 +35,8 @@ public class MappedState<T, TNew> : StateBase<TNew>, IState<TNew>, IDisposable {
 
     private static void HandleValueChanged(ref RefStateSubscription _, T value, object arg1, object arg2) {
         var self = (MappedState<T, TNew>)arg1;
-        
-        self._value = default;
+
+        self._hasValue = false;
 
         if (self.HasCallbacks) {
             self.NotifyValueChanged(self.Value);

--- a/src/reactive/Reactive/States/State.cs
+++ b/src/reactive/Reactive/States/State.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using JetBrains.Annotations;
 
 namespace Reactive {
     [PublicAPI]
-    public class State<T> : IMutableState<T> {
+    public class State<T> : StateBase<T>, IMutableState<T> {
         public State(T initialValue) {
             _value = initialValue;
         }
@@ -11,21 +11,16 @@ namespace Reactive {
         public T Value {
             get => _value;
             set {
+                if (EqualityComparer<T>.Default.Equals(value, _value)) {
+                    return;
+                }
+                
                 _value = value;
-                ValueChangedEvent?.Invoke(value);
-                StateUpdatedEvent?.Invoke();
+                NotifyValueChanged(value);
             }
         }
-
-        public event Action<T>? ValueChangedEvent;
-        public event Action? StateUpdatedEvent;
-
+        
         private T _value;
-
-        public void ClearBindings() {
-            ValueChangedEvent = null;
-            StateUpdatedEvent = null;
-        }
 
         public static implicit operator T(State<T> value) {
             return value._value;

--- a/src/reactive/Reactive/States/StateBase.cs
+++ b/src/reactive/Reactive/States/StateBase.cs
@@ -1,0 +1,37 @@
+using JetBrains.Annotations;
+
+namespace Reactive;
+
+/// <summary>
+/// A universal state base that implement the notification logic.
+/// It intentionally doesn't implement IState and IMutableState to let you chose
+/// what you need and avoid explicit interface implementations.
+/// </summary>
+/// <typeparam name="T">A type of the state.</typeparam>
+[PublicAPI]
+public abstract class StateBase<T> : IState {
+    private StateCallbacksList<T> _list;
+
+    // Helps to avoid evaluating Value when there's nothing to invoke
+    protected bool HasCallbacks => _list.HasCallbacks;
+
+    protected StateBase() {
+        _list = new(this);
+    }
+
+    protected void NotifyValueChanged(T value) {
+        _list.Invoke(value);
+    }
+
+    public StateSubscription AddCallback(StateCallback<T> callback, object arg1, object arg2) {
+        return _list.Add(callback, arg1, arg2);
+    }
+
+    public StateSubscription AddCallback(StateCallback callback, object arg1, object arg2) {
+        return _list.Add(callback, arg1, arg2);
+    }
+
+    public bool RemoveCallback(in StateSubscription sub) {
+        return _list.Remove(sub);
+    }
+}

--- a/src/reactive/Reactive/States/StateCallbacksList.cs
+++ b/src/reactive/Reactive/States/StateCallbacksList.cs
@@ -1,0 +1,129 @@
+using System;
+
+namespace Reactive;
+
+internal readonly struct StateCallbackEntry<T> {
+    public StateCallbackEntry(StateCallback callback, object arg1, object arg2) {
+        Callback = callback;
+        _arg1 = arg1;
+        _arg2 = arg2;
+        _typed = false;
+    }
+
+    public StateCallbackEntry(StateCallback<T> callback, object arg1, object arg2) {
+        Callback = callback;
+        _arg1 = arg1;
+        _arg2 = arg2;
+        _typed = true;
+    }
+
+    public readonly object Callback;
+
+    private readonly bool _typed;
+    private readonly object _arg1;
+    private readonly object _arg2;
+
+    public void Invoke(ref RefStateSubscription sub, T value) {
+        if (_typed) {
+            ((StateCallback<T>)Callback).Invoke(ref sub, value, _arg1, _arg2);
+        } else {
+            ((StateCallback)Callback).Invoke(ref sub, _arg1, _arg2);
+        }
+    }
+}
+
+/// <summary>
+/// Such types are usually classes, but as it's meant to be used in
+/// every state, making it a class would be a performance bottleneck 
+/// as each state would require an additional allocation. You should never clone this struct.
+/// </summary>
+public struct StateCallbacksList<T> {
+    private StateCallbackEntry<T>?[]? _array;
+    private int _lastAvailableSlot;
+    private readonly IState _state;
+
+    public bool HasCallbacks => _array?.Length > 0;
+
+    public StateCallbacksList(IState state) {
+        _state = state;
+    }
+
+    public void Invoke(T value) {
+        for (var i = 0; i < _array?.Length; i++) {
+            if (_array[i] == null) {
+                continue;
+            }
+
+            var sub = new RefStateSubscription(true);
+
+            _array[i]?.Invoke(ref sub, value);
+
+            if (!sub.GetIsValid()) {
+                _array[i] = null;
+            }
+        }
+    }
+
+    public StateSubscription Add(StateCallback callback, object arg1, object arg2) {
+        var slot = GetSlot();
+
+        _array![slot] = new(callback, arg1, arg2);
+        _lastAvailableSlot = slot + 1;
+
+        return new(slot, callback, _state);
+    }
+
+    public StateSubscription Add(StateCallback<T> callback, object arg1, object arg2) {
+        var slot = GetSlot();
+
+        _array![slot] = new(callback, arg1, arg2);
+        _lastAvailableSlot = slot + 1;
+
+        return new(slot, callback, _state);
+    }
+
+    public bool Remove(in StateSubscription sub) {
+        if (_array == null) {
+            return false;
+        }
+
+        var (i, cb, state) = sub.GetData();
+
+        if (!ReferenceEquals(_state, state) || _array.Length <= i) {
+            return false;
+        }
+
+        var callback = _array[i]?.Callback;
+
+        if (!ReferenceEquals(callback, cb)) {
+            return false;
+        }
+
+        _array[i] = null;
+        // When inserting new callbacks we use forward lookups,
+        // so we store the first unoccupied entry
+        if (i < _lastAvailableSlot) {
+            _lastAvailableSlot = i;
+        }
+
+        return true;
+    }
+
+    private int GetSlot() {
+        if (_array == null) {
+            _array = new StateCallbackEntry<T>?[4];
+            return 0;
+        }
+
+        var len = _array.Length;
+
+        for (var i = _lastAvailableSlot; i < len; i++) {
+            if (!_array[i].HasValue) {
+                return i;
+            }
+        }
+
+        Array.Resize(ref _array, _array.Length * 2);
+        return len;
+    }
+}

--- a/src/reactive/Reactive/States/StateExtensions.cs
+++ b/src/reactive/Reactive/States/StateExtensions.cs
@@ -32,112 +32,84 @@ namespace Reactive {
 
         #endregion
 
-        #region Animate
+        #region On
 
         extension<T>(IState<T> state) {
             /// <summary>
-            /// Attaches a callback to the state.
+            /// Binds a callback to some state.
             /// </summary>
-            /// <param name="callback">A callback to attach.</param>
-            public IState<T> Attach(Action<T> callback) {
-                state.ValueChangedEvent += callback;
-                return state;
-            }
-            
-            /// <summary>
-            /// Detaches the specified callback.
-            /// </summary>
-            /// <param name="callback">A callback to detach.</param>
-            public IState<T> Detach(Action<T> callback) {
-                state.ValueChangedEvent -= callback;
-                return state;
-            }
-        }
+            /// <param name="callback">A callback to bind.</param>
+            /// <param name="lazy">Whether the callback should be invoked immediately.</param>
+            public StateSubscription AddCallback(Action<T> callback, bool lazy = false) {
+                var sub = state.AddCallback(Wrapper, callback, null!);
 
-        /// <summary>
-        /// Attaches a callback to a state that returns a float,
-        /// interpolating it using the provided curve.
-        /// </summary>
-        /// <param name="callback">A callback to attach.</param>
-        public static IState<float> AttachLerp(this IState<float> state, Action<float> callback, AnimationCurve curve) {
-            state.ValueChangedEvent += t => callback(curve.Evaluate(t));
-            return state;
+                if (!lazy) {
+                    var refHandle = new RefStateSubscription(true);
+                    Wrapper(ref refHandle, state.Value, callback, null!);
+
+                    if (!refHandle.GetIsValid()) {
+                        state.RemoveCallback(sub);
+                    }
+                }
+
+                return sub;
+
+                static void Wrapper(ref RefStateSubscription sub, T val, object arg1, object arg2) {
+                    ((Action<T>)arg1)(val);
+                }
+            }
+
+            /// <summary>
+            /// Binds a callback to some state capturing an IReactiveComponent.
+            /// </summary>
+            /// <param name="comp">A component to capture.</param>
+            /// <param name="callback">A callback to bind.</param>
+            /// <param name="lazy">Whether the callback should be invoked immediately.</param>
+            public StateSubscription AddCallback<TComp>(TComp comp, Action<TComp, T> callback, bool lazy = false) where TComp : IReactiveComponent {
+                var sub = state.AddCallback(Wrapper, comp, callback);
+
+                if (!lazy) {
+                    var refHandle = new RefStateSubscription(true);
+                    Wrapper(ref refHandle, state.Value, comp, callback);
+
+                    if (!refHandle.GetIsValid()) {
+                        state.RemoveCallback(sub);
+                    }
+                }
+
+                return sub;
+
+                static void Wrapper(ref RefStateSubscription sub, T val, object arg1, object arg2) {
+                    var comp = (TComp)arg1;
+                    var callback = (Action<TComp, T>)arg2;
+
+                    // Return if component is not valid yet
+                    if (!comp.IsInitialized) {
+                        return;
+                    }
+
+                    // Unsubscribe if component is not valid anymore
+                    if (comp.IsDestroyed) {
+                        sub.RemoveCallback();
+                        return;
+                    }
+
+                    callback(comp, val);
+                }
+            }
         }
 
         // Note: methods use duplicated logic rather than wrapping
         // as each wrap costs a heap allocation
         extension<T>(T comp) where T : IReactiveComponent {
             /// <summary>
-            /// This method uses expression parsing to generate callbacks in runtime.
-            /// Runtime generation is very expensive and is already replaced by
-            /// much faster and convenient property extensions, so this method is considered obsolete now.
-            /// </summary>
-            [Obsolete("Use bindings generator instead")]
-            public T Animate<TValue>(IState<TValue> value, Expression<Func<T, TValue>> expression, bool applyImmediately = false) {
-                var setter = expression.GeneratePropertySetter();
-
-                return On(comp, value, setter, applyImmediately);
-            }
-
-            /// <summary>
             /// Binds a callback to some state.
             /// </summary>
-            /// <param name="value">A state to bind to.</param>
-            /// <param name="onEffect">A callback to bind.</param>
-            /// <param name="applyImmediately">Whether the callback should be invoked immediately.</param>
-            public T On<TValue>(IState<TValue> value, Action<TValue> onEffect, bool applyImmediately = false) {
-                void Closure(TValue val) {
-                    // Return if component is not valid yet
-                    if (!comp.IsInitialized) {
-                        return;
-                    }
-
-                    // Unsubscribe if component is not valid anymore
-                    if (comp.IsDestroyed) {
-                        value.ValueChangedEvent -= Closure;
-                        return;
-                    }
-
-                    onEffect(val);
-                }
-
-                value.ValueChangedEvent += Closure;
-
-                if (applyImmediately) {
-                    Closure(value.Value);
-                }
-
-                return comp;
-            }
-
-            /// <summary>
-            /// Binds a callback to some state.
-            /// </summary>
-            /// <param name="value">A state to bind to.</param>
-            /// <param name="onEffect">A callback to bind.</param>
-            /// <param name="applyImmediately">Whether the callback should be invoked immediately.</param>
-            public T On<TValue>(IState<TValue> value, Action<T, TValue> onEffect, bool applyImmediately = false) {
-                void Closure(TValue val) {
-                    // Return if component is not valid yet
-                    if (!comp.IsInitialized) {
-                        return;
-                    }
-
-                    // Unsubscribe if component is not valid anymore
-                    if (comp.IsDestroyed) {
-                        value.ValueChangedEvent -= Closure;
-                        return;
-                    }
-
-                    onEffect(comp, val);
-                }
-
-                value.ValueChangedEvent += Closure;
-
-                if (applyImmediately) {
-                    Closure(value.Value);
-                }
-
+            /// <param name="state">A state to bind to.</param>
+            /// <param name="callback">A callback to bind.</param>
+            /// <param name="lazy">Whether the callback should be invoked immediately.</param>
+            public T On<TValue>(IState<TValue> state, Action<T, TValue> callback, bool lazy = false) {
+                state.AddCallback(comp, callback, lazy);
                 return comp;
             }
         }

--- a/src/reactive/Reactive/States/StateExtensions.cs
+++ b/src/reactive/Reactive/States/StateExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
 
 namespace Reactive {
@@ -41,18 +40,7 @@ namespace Reactive {
             /// <param name="callback">A callback to bind.</param>
             /// <param name="lazy">Whether the callback should be invoked immediately.</param>
             public StateSubscription AddCallback(Action<T> callback, bool lazy = false) {
-                var sub = state.AddCallback(Wrapper, callback, null!);
-
-                if (!lazy) {
-                    var refHandle = new RefStateSubscription(true);
-                    Wrapper(ref refHandle, state.Value, callback, null!);
-
-                    if (!refHandle.GetIsValid()) {
-                        state.RemoveCallback(sub);
-                    }
-                }
-
-                return sub;
+                return state.AddCallbackInternal(lazy, Wrapper, callback, null!);
 
                 static void Wrapper(ref RefStateSubscription sub, T val, object arg1, object arg2) {
                     ((Action<T>)arg1)(val);
@@ -65,31 +53,15 @@ namespace Reactive {
             /// <param name="comp">A component to capture.</param>
             /// <param name="callback">A callback to bind.</param>
             /// <param name="lazy">Whether the callback should be invoked immediately.</param>
-            public StateSubscription AddCallback<TComp>(TComp comp, Action<TComp, T> callback, bool lazy = false) where TComp : IReactiveComponent {
-                var sub = state.AddCallback(Wrapper, comp, callback);
-
-                if (!lazy) {
-                    var refHandle = new RefStateSubscription(true);
-                    Wrapper(ref refHandle, state.Value, comp, callback);
-
-                    if (!refHandle.GetIsValid()) {
-                        state.RemoveCallback(sub);
-                    }
-                }
-
-                return sub;
+            public StateSubscription AddCallback<TComp>(TComp comp, Action<TComp, T> callback, bool lazy = false) where TComp : ILifetimeProvider {
+                return state.AddCallbackInternal(lazy, Wrapper, comp, callback);
 
                 static void Wrapper(ref RefStateSubscription sub, T val, object arg1, object arg2) {
                     var comp = (TComp)arg1;
                     var callback = (Action<TComp, T>)arg2;
 
-                    // Return if component is not valid yet
-                    if (!comp.IsInitialized) {
-                        return;
-                    }
-
                     // Unsubscribe if component is not valid anymore
-                    if (comp.IsDestroyed) {
+                    if (!comp.IsAlive) {
                         sub.RemoveCallback();
                         return;
                     }
@@ -97,18 +69,56 @@ namespace Reactive {
                     callback(comp, val);
                 }
             }
+
+            /// <summary>
+            /// Binds a callback to some state capturing a unity object.
+            /// </summary>
+            /// <param name="comp">A component to capture.</param>
+            /// <param name="callback">A callback to bind.</param>
+            /// <param name="lazy">Whether the callback should be invoked immediately.</param>
+            public StateSubscription AddCallbackUnity<TComp>(TComp comp, Action<TComp, T> callback, bool lazy = false) where TComp : UnityEngine.Object {
+                return state.AddCallbackInternal(lazy, Wrapper, comp, callback);
+
+                static void Wrapper(ref RefStateSubscription sub, T val, object arg1, object arg2) {
+                    var comp = (TComp)arg1;
+                    var callback = (Action<TComp, T>)arg2;
+
+                    // Unsubscribe if component is not valid anymore
+                    if (!comp.IsAlive) {
+                        sub.RemoveCallback();
+                        return;
+                    }
+
+                    callback(comp, val);
+                }
+            }
+
+            private StateSubscription AddCallbackInternal(bool lazy, StateCallback<T> callback, object arg1, object arg2) {
+                var sub = state.AddCallback(callback, arg1, arg2);
+
+                if (!lazy) {
+                    var refHandle = new RefStateSubscription(true);
+                    callback(ref refHandle, state.Value, arg1, arg2);
+
+                    if (!refHandle.GetIsValid()) {
+                        sub.RemoveCallback();
+                    }
+                }
+
+                return sub;
+            }
         }
 
         // Note: methods use duplicated logic rather than wrapping
         // as each wrap costs a heap allocation
-        extension<T>(T comp) where T : IReactiveComponent {
+        extension<TComp>(TComp comp) where TComp : ILifetimeProvider {
             /// <summary>
             /// Binds a callback to some state.
             /// </summary>
             /// <param name="state">A state to bind to.</param>
             /// <param name="callback">A callback to bind.</param>
             /// <param name="lazy">Whether the callback should be invoked immediately.</param>
-            public T On<TValue>(IState<TValue> state, Action<T, TValue> callback, bool lazy = false) {
+            public TComp On<T>(IState<T> state, Action<TComp, T> callback, bool lazy = false) {
                 state.AddCallback(comp, callback, lazy);
                 return comp;
             }

--- a/src/reactive/Reactive/States/StateSubscription.cs
+++ b/src/reactive/Reactive/States/StateSubscription.cs
@@ -27,6 +27,8 @@ public readonly struct StateSubscription {
     }
 
     public void RemoveCallback() {
+        EnsureInitialized();
+        
         _state.RemoveCallback(this);
     }
 

--- a/src/reactive/Reactive/States/StateSubscription.cs
+++ b/src/reactive/Reactive/States/StateSubscription.cs
@@ -1,0 +1,59 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Reactive;
+
+/// <summary>
+/// A persistent handle that's required to remove a bound callback.
+/// </summary>
+[PublicAPI]
+public readonly struct StateSubscription {
+    private readonly int _index;
+    private readonly object _callback;
+    private readonly IState _state;
+    private readonly bool _isValid;
+
+    public StateSubscription(int index, object callback, IState state) {
+        _index = index;
+        _callback = callback;
+        _state = state;
+        _isValid = true;
+    }
+
+    public (int index, object callback, IState state) GetData() {
+        EnsureInitialized();
+
+        return (_index, _callback, _state);
+    }
+
+    public void RemoveCallback() {
+        _state.RemoveCallback(this);
+    }
+
+    private void EnsureInitialized() {
+        if (!_isValid) {
+            throw new InvalidOperationException("Called GetData on an invalidated subscription");
+        }
+    }
+}
+
+/// <summary>
+/// A temporary handle that exposes an api to remove the callback.
+/// </summary>
+[PublicAPI]
+public ref struct RefStateSubscription {
+    // Ref fields aren't supported by Mono, so we rely on passing the entire struct by ref instead
+    private bool _isValid;
+
+    public RefStateSubscription(bool isValid) {
+        _isValid = isValid;
+    }
+
+    public void RemoveCallback() {
+        _isValid = false;
+    }
+
+    public bool GetIsValid() {
+        return _isValid;
+    }
+}


### PR DESCRIPTION
This PR fixes two major problems: per-binding delegate allocation and state lifetimes. Now states check whether the object is alive before performing a call. Besides that events got removed in favor of plain arrays to reduce GC pressure and provide slot stability (so bindings can be removed without lookups).